### PR TITLE
Add CacheHelper for managing SharedPreferences

### DIFF
--- a/lib/core/database/cache/shared_preferences.dart
+++ b/lib/core/database/cache/shared_preferences.dart
@@ -1,0 +1,20 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class CacheHelper {
+  late SharedPreferences sharedPreferences;
+  Future<void> init() async {
+    sharedPreferences = await SharedPreferences.getInstance();
+  }
+
+  Future<void> saveData({required String key, required bool value}) async {
+    await sharedPreferences.setBool(key, value);
+  }
+
+  bool? getData({required String key}) {
+    return sharedPreferences.getBool(key);
+  }
+}
+
+abstract class CacheKeys {
+  static const String isFirstTime = 'isFirstTime';
+}

--- a/lib/core/service/service_locator.dart
+++ b/lib/core/service/service_locator.dart
@@ -1,5 +1,6 @@
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
+import 'package:testfirebase/core/database/cache/shared_preferences.dart';
 import 'package:testfirebase/features/home/data/repo/home_repo.dart';
 import 'package:testfirebase/features/reset_password/data/repo/reset_password_repo.dart';
 import 'package:testfirebase/features/sign_in/data/repo/sign_in_repo.dart';
@@ -15,5 +16,6 @@ void setup() {
   getIt.registerLazySingleton(() => ResetPasswordRepo());
   getIt.registerLazySingleton(() => HomeRepo());
   getIt.registerLazySingleton(() => AudioPlayer());
+  getIt.registerLazySingleton(() => CacheHelper());
 
 }

--- a/lib/features/home/presentation/view/home.dart
+++ b/lib/features/home/presentation/view/home.dart
@@ -1,7 +1,10 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
+import 'package:testfirebase/core/helpers/extentions.dart';
+import 'package:testfirebase/core/routes/routing.dart';
 import 'package:testfirebase/core/utils/app_color.dart';
 import 'package:testfirebase/core/utils/app_fonts.dart';
 import 'package:testfirebase/core/widgets/doting_loading_indicator.dart';
@@ -18,7 +21,11 @@ class Home extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
-          onPressed: () {},
+          onPressed: () {
+            FirebaseAuth.instance.signOut();
+            context.pushNamedAndRemoveUntil(Routing.init,
+                predicate: (routing) => false);
+          },
           icon: const Icon(Icons.filter_list),
         ),
         title: Text(

--- a/lib/features/onboarding/presentation/controller/cubit/onboarding_cubit.dart
+++ b/lib/features/onboarding/presentation/controller/cubit/onboarding_cubit.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:testfirebase/core/database/cache/shared_preferences.dart';
 import 'package:testfirebase/core/helpers/extentions.dart';
 import 'package:testfirebase/core/routes/routing.dart';
+import 'package:testfirebase/core/service/service_locator.dart';
 
 part 'onboarding_state.dart';
 
 class OnboardingCubit extends Cubit<OnboardingState> {
-  OnboardingCubit() : super(OnboardingInitial());
+  OnboardingCubit() : super(OnboardingInitial()) {
+    getIt<CacheHelper>().saveData(key: CacheKeys.isFirstTime, value: true);
+  }
   static OnboardingCubit get(context) => BlocProvider.of(context);
   int indicator = 0;
   String text = 'NEXT';

--- a/lib/features/onboarding/presentation/view/onboarding.dart
+++ b/lib/features/onboarding/presentation/view/onboarding.dart
@@ -1,6 +1,4 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:testfirebase/core/database/cache/shared_preferences.dart';
 import 'package:testfirebase/core/helpers/bloc_observer.dart';
 import 'package:testfirebase/core/routes/app_routers.dart';
 import 'package:testfirebase/core/service/service_locator.dart';
@@ -16,6 +17,7 @@ void main() async {
   );
   Bloc.observer = MyBlocObserver();
   setup();
+  getIt<CacheHelper>().init();
   runApp(
     DevicePreview(
       builder: (context) => TodoApp(

--- a/lib/todo_app.dart
+++ b/lib/todo_app.dart
@@ -1,7 +1,9 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:testfirebase/core/database/cache/shared_preferences.dart';
 import 'package:testfirebase/core/routes/app_routers.dart';
 import 'package:testfirebase/core/routes/routing.dart';
+import 'package:testfirebase/core/service/service_locator.dart';
 import 'package:testfirebase/core/utils/app_theme.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
@@ -13,14 +15,21 @@ class TodoApp extends StatelessWidget {
     return ScreenUtilInit(
       designSize: const Size(375, 812),
       child: MaterialApp(
-        initialRoute: (FirebaseAuth.instance.currentUser != null &&
-                FirebaseAuth.instance.currentUser!.emailVerified)
-            ? Routing.home
-            : Routing.init,
+        initialRoute: getInitRoute(),
         debugShowCheckedModeBanner: false,
         onGenerateRoute: appRouter.generateRoute,
         theme: appTheme(),
       ),
     );
+  }
+
+  String getInitRoute() {
+    if (getIt<CacheHelper>().getData(key: CacheKeys.isFirstTime) == null) {
+      return Routing.init;
+    }
+    return (FirebaseAuth.instance.currentUser != null &&
+            FirebaseAuth.instance.currentUser!.emailVerified)
+        ? Routing.home
+        : Routing.signIn;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -702,7 +702,7 @@ packages:
     source: hosted
     version: "6.1.2"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
       sha256: "81429e4481e1ccfb51ede496e916348668fd0921627779233bd24cc3ff6abd02"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   google_fonts: ^6.2.1
   google_sign_in: ^6.2.1
   logger: ^2.1.0
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_launcher_icons: ^0.13.1


### PR DESCRIPTION
- Add CacheHelper class to manage SharedPreferences for caching data.
- Register CacheHelper with service locator for dependency injection.
- Initialize CacheHelper in the main app to handle caching logic.