### PR TITLE
Refactor code to update task list in calendar view

### DIFF
--- a/lib/core/routes/app_routers.dart
+++ b/lib/core/routes/app_routers.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:testfirebase/core/model/task_model.dart';
 import 'package:testfirebase/core/routes/routing.dart';
+import 'package:testfirebase/features/calender/presentation/controller/calender_cubit/calender_cubit.dart';
 import 'package:testfirebase/features/foucs/presentation/view/counter_cubit/counter_cubit.dart';
 import 'package:testfirebase/features/home/presentation/controller/change_route_cubit/change_route_cubit.dart';
 import 'package:testfirebase/features/home/presentation/controller/fold_done_list_cubit/fold_done_list_cubit.dart';
@@ -44,8 +45,11 @@ class AppRouter {
                 create: (context) => FoldDoneListCubit(),
               ),
               BlocProvider(
+                create: (context) => CalenderCubit(),
+              ),
+              BlocProvider(
                 create: (context) => CounterCubit(),
-              )
+              ),
             ],
             child: const MainScreen(),
           ),

--- a/lib/features/calender/presentation/controller/calender_cubit/calender_cubit.dart
+++ b/lib/features/calender/presentation/controller/calender_cubit/calender_cubit.dart
@@ -3,17 +3,17 @@ import 'package:testfirebase/core/model/task_model.dart';
 import 'package:testfirebase/features/calender/presentation/controller/calender_cubit/calender_state.dart';
 
 class CalenderCubit extends Cubit<CalenderState> {
-  CalenderCubit(this.tasks) : super(CalenderInitial());
-  final List<TaskModel> tasks;
+  CalenderCubit(/*this.tasks*/) : super(CalenderInitial());
+  // final List<TaskModel> tasks;
   List<TaskModel> filteredList = [];
   static CalenderCubit get(context) => BlocProvider.of(context);
   DateTime selectedDate = DateTime.now();
-  void changeSelectedDay(DateTime date) {
+  void changeSelectedDay(DateTime date,List<TaskModel> tasks) {
     selectedDate = date;
-    filterTasksByDueDate();
+    filterTasksByDueDate(tasks: tasks);
   }
 
-  void filterTasksByDueDate() {
+  void filterTasksByDueDate({required List<TaskModel> tasks}) {
     emit(FilterListLoading());
     try {
       filteredList =

--- a/lib/features/calender/presentation/view/calender.dart
+++ b/lib/features/calender/presentation/view/calender.dart
@@ -7,6 +7,7 @@ import 'package:table_calendar/table_calendar.dart';
 import 'package:testfirebase/core/widgets/list_of_tasks.dart';
 import 'package:testfirebase/features/calender/presentation/controller/calender_cubit/calender_cubit.dart';
 import 'package:testfirebase/features/calender/presentation/controller/calender_cubit/calender_state.dart';
+import 'package:testfirebase/features/home/presentation/controller/home/home_cubit.dart';
 
 import '../../../task_details/presentation/controller/cubit/edit_task_cubit.dart';
 import '../../../task_details/presentation/controller/cubit/edit_task_state.dart';
@@ -20,7 +21,9 @@ class Calender extends StatelessWidget {
       builder: (context, state) {
         return CustomScrollView(
           slivers: [
-            SliverToBoxAdapter(child: Gap(20.h),),
+            SliverToBoxAdapter(
+              child: Gap(30.h),
+            ),
             SliverToBoxAdapter(
               child: TableCalendar(
                 calendarStyle: const CalendarStyle(
@@ -32,7 +35,8 @@ class Calender extends StatelessWidget {
                 firstDay: DateTime(2000),
                 lastDay: DateTime(2030),
                 onDaySelected: (selectedDay, focusedDay) {
-                  CalenderCubit.get(context).changeSelectedDay(selectedDay);
+                  CalenderCubit.get(context).changeSelectedDay(
+                      selectedDay, HomeCubit.get(context).userTasks);
                 },
                 selectedDayPredicate: (day) =>
                     isSameDay(day, CalenderCubit.get(context).selectedDate),
@@ -43,6 +47,9 @@ class Calender extends StatelessWidget {
                 return ListOfTasks(
                     tasks: CalenderCubit.get(context).filteredList);
               },
+            ),
+            SliverToBoxAdapter(
+              child: Gap(20.h),
             )
           ],
         );

--- a/lib/features/home/presentation/controller/change_route_cubit/change_route_cubit.dart
+++ b/lib/features/home/presentation/controller/change_route_cubit/change_route_cubit.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:testfirebase/features/calender/presentation/controller/calender_cubit/calender_cubit.dart';
 import 'package:testfirebase/features/calender/presentation/view/calender.dart';
 import 'package:testfirebase/features/foucs/presentation/view/focus.dart';
 import 'package:testfirebase/features/home/presentation/controller/change_route_cubit/change_route_state.dart';
-import 'package:testfirebase/features/home/presentation/controller/home/home_cubit.dart';
+
 import 'package:testfirebase/features/home/presentation/view/widgets/tasks_body.dart';
 import 'package:testfirebase/features/profile/presentation/view/profile.dart';
 import 'package:testfirebase/features/task_details/presentation/controller/cubit/edit_task_cubit.dart';
@@ -15,16 +14,8 @@ class ChangeRouteCubit extends Cubit<ChangeRouteState> {
 
   List<Widget> routes = [
     const TasksBody(),
-    MultiBlocProvider(
-      providers: [
-        BlocProvider(
-          create: (context) => CalenderCubit(HomeCubit.get(context).userTasks)
-            ..filterTasksByDueDate(),
-        ),
-        BlocProvider(
-          create: (context) => EditTaskCubit(),
-        ),
-      ],
+    BlocProvider(
+      create: (context) => EditTaskCubit(),
       child: const Calender(),
     ),
     const FocusRoute(),

--- a/lib/features/home/presentation/view/widgets/add_item_section.dart
+++ b/lib/features/home/presentation/view/widgets/add_item_section.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:testfirebase/core/utils/app_color.dart';
+import 'package:testfirebase/features/calender/presentation/controller/calender_cubit/calender_cubit.dart';
 import 'package:testfirebase/features/home/presentation/controller/add_task/add_task_cubit.dart';
 import 'package:testfirebase/features/home/presentation/controller/home/home_cubit.dart';
 import 'package:testfirebase/features/home/presentation/view/widgets/add_task_dialog.dart';
@@ -19,11 +22,23 @@ class AddItemSection extends StatelessWidget {
             create: (context) => AddTaskCubit(),
             child: const AddTaskDialog(),
           ),
-        ).then((value) {
-          if (value != null) {
-            HomeCubit.get(context).getTasks();
-          }
-        });
+        ).then(
+          (value) {
+            if (value != null) {
+              StreamSubscription? subscription;
+              subscription = HomeCubit.get(context).stream.listen(
+                (state) {
+                  if (state is GetTaskSuccess) {
+                    subscription?.cancel();
+                    CalenderCubit.get(context).filterTasksByDueDate(
+                        tasks: HomeCubit.get(context).userTasks);
+                  }
+                },
+              );
+              HomeCubit.get(context).getTasks();
+            }
+          },
+        );
       },
       child: CircleAvatar(
         radius: 35.r,

--- a/lib/features/home/presentation/view/widgets/add_task_dialog.dart
+++ b/lib/features/home/presentation/view/widgets/add_task_dialog.dart
@@ -47,7 +47,7 @@ class AddTaskDialog extends StatelessWidget {
             Row(
               children: [
                 IconButton(
-                  onPressed: () => pickDateTime(context),
+                  onPressed: () => _pickDateTime(context),
                   icon: SvgPicture.asset(
                     AppIcons.iconsTimer,
                   ),
@@ -90,17 +90,17 @@ class AddTaskDialog extends StatelessWidget {
     );
   }
 
-  Future<DateTime?> pickDate(BuildContext context) => showDatePicker(
+  Future<DateTime?> _pickDate(BuildContext context) => showDatePicker(
       context: context, firstDate: DateTime.now(), lastDate: DateTime(2050));
 
-  Future<TimeOfDay?> pickTime(BuildContext context) =>
+  Future<TimeOfDay?> _pickTime(BuildContext context) =>
       showTimePicker(context: context, initialTime: TimeOfDay.now());
 
-  Future pickDateTime(BuildContext context) async {
+  Future _pickDateTime(BuildContext context) async {
     FocusManager.instance.primaryFocus?.unfocus();
-    DateTime? date = await pickDate(context);
+    DateTime? date = await _pickDate(context);
     if (date == null) return;
-    TimeOfDay? time = await pickTime(context);
+    TimeOfDay? time = await _pickTime(context);
     if (time == null) return;
     AddTaskCubit.get(context).dueDate = DateTime(
       date.year,

--- a/lib/features/home/presentation/view/widgets/nav_bar_indexs_section.dart
+++ b/lib/features/home/presentation/view/widgets/nav_bar_indexs_section.dart
@@ -4,8 +4,10 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
 import 'package:testfirebase/core/utils/app_color.dart';
 import 'package:testfirebase/core/utils/app_icons.dart';
+import 'package:testfirebase/features/calender/presentation/controller/calender_cubit/calender_cubit.dart';
 import 'package:testfirebase/features/home/presentation/controller/change_route_cubit/change_route_cubit.dart';
 import 'package:testfirebase/features/home/presentation/controller/change_route_cubit/change_route_state.dart';
+import 'package:testfirebase/features/home/presentation/controller/home/home_cubit.dart';
 import 'package:testfirebase/features/home/presentation/view/widgets/nav_bar_index.dart';
 import 'package:testfirebase/generated/l10n.dart';
 
@@ -26,7 +28,7 @@ class IndexSection extends StatelessWidget {
               NavBarIndex(
                 iconPath: ChangeRouteCubit.get(context).currentRoute == 0
                     ? AppIcons.iconsSelectedHome
-                    :  AppIcons.iconsUnselectedHome,
+                    : AppIcons.iconsUnselectedHome,
                 title: S.of(context).index,
                 onTap: () {
                   ChangeRouteCubit.get(context).changeRoute(index: 0);
@@ -36,16 +38,18 @@ class IndexSection extends StatelessWidget {
               NavBarIndex(
                 iconPath: ChangeRouteCubit.get(context).currentRoute == 1
                     ? AppIcons.iconsSelectedCalendar
-                    :  AppIcons.iconsUnselectedCalendar,
+                    : AppIcons.iconsUnselectedCalendar,
                 title: S.of(context).Calender,
                 onTap: () {
                   ChangeRouteCubit.get(context).changeRoute(index: 1);
+                  CalenderCubit.get(context).filterTasksByDueDate(
+                      tasks: HomeCubit.get(context).userTasks);
                 },
               ),
               const Spacer(),
               NavBarIndex(
                 iconPath: ChangeRouteCubit.get(context).currentRoute == 2
-                    ?  AppIcons.iconsSelectedClock
+                    ? AppIcons.iconsSelectedClock
                     : AppIcons.iconsUnselectedClock,
                 title: S.of(context).Focus,
                 onTap: () {

--- a/lib/features/home/presentation/view/widgets/task_card.dart
+++ b/lib/features/home/presentation/view/widgets/task_card.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -10,6 +12,7 @@ import 'package:testfirebase/core/routes/routing.dart';
 import 'package:testfirebase/core/service/service_locator.dart';
 import 'package:testfirebase/core/utils/app_color.dart';
 import 'package:testfirebase/core/utils/app_fonts.dart';
+import 'package:testfirebase/features/calender/presentation/controller/calender_cubit/calender_cubit.dart';
 import 'package:testfirebase/features/home/presentation/controller/edit_task_details_cubit/edit_task_details_cubit.dart';
 import 'package:testfirebase/features/home/presentation/controller/home/home_cubit.dart';
 import 'package:testfirebase/features/home/presentation/view/widgets/delete_task_dialog.dart';
@@ -29,52 +32,75 @@ class TaskCard extends StatelessWidget {
         context.pushReplacementNamed(Routing.taskDetails, argument: task);
       },
       child: Slidable(
-        endActionPane: ActionPane(motion: const StretchMotion(), children: [
-          SlidableAction(
-            onPressed: (_) {
-              showDialog(
-                context: context,
-                builder: (context) => BlocProvider(
-                  create: (context) => EditTaskCubit(),
-                  child: DeleteTaskDialog(docID: task.docID),
-                ),
-              ).then(
-                (value) {
-                  if (value != null) {
-                    HomeCubit.get(context).getTasks();
-                  }
-                },
-              );
-            },
-            backgroundColor: AppColor.red,
-            foregroundColor: AppColor.white,
-            icon: Icons.delete,
-            label: S.of(context).delete,
-          ),
-          SlidableAction(
-            onPressed: (_) {
-              showDialog(
-                context: context,
-                builder: (context) => BlocProvider(
-                  create: (context) => EditTaskDetailsCubit(task),
-                  child: EditTaskDialog(
-                    task: task,
+        endActionPane: ActionPane(
+          motion: const StretchMotion(),
+          children: [
+            SlidableAction(
+              onPressed: (_) {
+                showDialog(
+                  context: context,
+                  builder: (context) => BlocProvider(
+                    create: (context) => EditTaskCubit(),
+                    child: DeleteTaskDialog(docID: task.docID),
                   ),
-                ),
-              ).then(
-                (value) {
-                  if (value != null) {
-                    HomeCubit.get(context).getTasks();
-                  }
-                },
-              );
-            },
-            backgroundColor: AppColor.aqua,
-            foregroundColor: AppColor.white,
-            icon: Icons.edit,
-            label: S.of(context).edit,
-          ),
-        ]),
+                ).then(
+                  (value) {
+                    if (value != null) {
+                      StreamSubscription? subscription;
+                      subscription = HomeCubit.get(context).stream.listen(
+                        (state) {
+                          if (state is GetTaskSuccess) {
+                            subscription?.cancel();
+                            CalenderCubit.get(context).filterTasksByDueDate(
+                                tasks: HomeCubit.get(context).userTasks);
+                          }
+                        },
+                      );
+                      HomeCubit.get(context).getTasks();
+                    }
+                  },
+                );
+              },
+              backgroundColor: AppColor.red,
+              foregroundColor: AppColor.white,
+              icon: Icons.delete,
+              label: S.of(context).delete,
+            ),
+            SlidableAction(
+              onPressed: (_) {
+                showDialog(
+                  context: context,
+                  builder: (context) => BlocProvider(
+                    create: (context) => EditTaskDetailsCubit(task),
+                    child: EditTaskDialog(
+                      task: task,
+                    ),
+                  ),
+                ).then(
+                  (value) {
+                    if (value != null) {
+                      StreamSubscription? subscription;
+                      subscription = HomeCubit.get(context).stream.listen(
+                        (state) {
+                          if (state is GetTaskSuccess) {
+                            subscription?.cancel();
+                            CalenderCubit.get(context).filterTasksByDueDate(
+                                tasks: HomeCubit.get(context).userTasks);
+                          }
+                        },
+                      );
+                      HomeCubit.get(context).getTasks();
+                    }
+                  },
+                );
+              },
+              backgroundColor: AppColor.aqua,
+              foregroundColor: AppColor.white,
+              icon: Icons.edit,
+              label: S.of(context).edit,
+            ),
+          ],
+        ),
         child: Container(
           padding: EdgeInsets.symmetric(vertical: 16.h),
           width: double.infinity,


### PR DESCRIPTION
- Added `CalenderCubit` to `AppRouter` for filtering tasks by due date in calendar view
- Updated `Calender` widget to pass `userTasks` to `changeSelectedDay` method and filter tasks by due date
- Updated `ChangeRouteCubit` to remove `CalenderCubit` from `MultiBlocProvider` and add it to `NavBarIndexsSection` to filter tasks by due date when navigating to calendar view
- Updated `AddItemSection` to listen to `HomeCubit` stream and filter tasks by due date after adding a new task
- Updated `TaskCard` to listen to `HomeCubit` stream and filter tasks by due date after deleting or editing a task. Also, added `StreamSubscription` to cancel the stream after updating the task list.